### PR TITLE
Don't save or report bw results if testing didn't complete before user n...

### DIFF
--- a/plugins/bw.js
+++ b/plugins/bw.js
@@ -538,8 +538,6 @@ BOOMR.plugins.BW = {
 
 	skip: function() {
 		// this is called on unload, so we should abort the test
-		// if it's already started and report results.
-		this.abort();
 
 		// it's also possible that we didn't start, so sendBeacon never
 		// gets called.  Let's set our complete state and call sendBeacon.


### PR DESCRIPTION
...avigates off page.

If a user navigates away from a page on which bandwidth is being tested
(i.e. before the file download probes are finished), the accuracy of
the results vary widely.

Therefore, don't save or report bw results if testing didn't complete
before user navigates off page.

A side-effect of this change is that bw testing will run on subsequent
pages until is finishes (which only requires that a user remain on a
page for 15s, so valid data should come quickly).
