### PR TITLE
Add initiator type to Resource Timing data

### DIFF
--- a/plugins/restiming.js
+++ b/plugins/restiming.js
@@ -40,7 +40,7 @@ impl = {
 				for(i = 0; i < r.length; ++i) {
 					data.restiming[i] = {
 						rt_name: r[i].name,
-						rt_type: r[i].initiatorType,
+						rt_in_type: r[i].initiatorType,
 						rt_st: r[i].startTime,
 						rt_dur: r[i].duration,
 						rt_fet_st: r[i].fetchStart,


### PR DESCRIPTION
I just had the spec open while updating my server code and realised that `initiatorType` is the thing I thought `entryType` was before. Not sure if you think it belongs in the request or not, but I'd find it quite useful for filtering/grouping data by resource type.
