### PR TITLE
clicks.js: Plugin for clicktracking

### DIFF
--- a/plugins/clicks.js
+++ b/plugins/clicks.js
@@ -1,0 +1,145 @@
+/**
+\file clicks.js
+A plugin beaconing clicked elements back to the server
+*/
+
+// w is the window object
+(function(w) {
+
+var d=w.document;
+
+    // First make sure BOOMR is actually defined.  It's possible that your plugin is
+    // loaded before boomerang, in which case you'll need this.
+    BOOMR = BOOMR || {};
+    BOOMR.plugins = BOOMR.plugins || {};
+    
+    // A private object to encapsulate all your implementation details
+    // This is optional, but the way we recommend you do it.
+    var impl = {
+	start_time: "",
+	click_url: "",
+	onbeforeunload: false,
+	retention: [],
+	handleEvent : function(event) {
+	    if (typeof impl.click_url === "undefined" ) {
+		BOOMR.error("No Beacon URL defined will not send beacon");
+		return;
+	    }
+	    
+	    var target = null;
+	    if (event.target) { target = event.target; }
+	    else if (event.srcElement) { target = event.srcElement; } 
+	    var document_res = impl.getDocumentSize();
+	    var viewport = impl.getViewport();
+	    var data = {
+		element: target.nodeName,
+		id: target.id,
+		"class" : target.classList,
+		x: event.x,
+		y: event.y,
+		document_height: document_res.height,
+		document_width: document_res.width,
+		viewport_height: viewport.height,
+		viewport_width: viewport.width
+	    };
+	    
+	    if (typeof impl.onbeforeunload === "undefined" || impl.onbeforeunload === false ) {
+		BOOMR.info("No preference set for when to send clickstats, will default to send immediately");
+		impl.sendData(data);
+	    } else {
+		impl.retention.push(data);
+	    }
+	},
+	sendData : function(data) {
+	    var keys = Object.keys(data);
+	    var urlenc = "";
+	    for (var i in keys) {
+		urlenc += keys[i] + "=" + data[keys[i]] + "&";
+	    }
+	    BOOMR.info("Url-encoded string: " + urlenc);
+	    var url = impl.click_url + "?" + urlenc;
+	    var img = new Image();
+	    img.src = url;
+	    img.remove();
+	},
+	unload : function() {
+	    impl.retention.forEach(function(data){
+		impl.sendData(data);
+	    });
+	},
+	getDocumentSize : function() {
+	    return { 
+		height:  Math.max(
+		    d.body.scrollHeight, d.documentElement.scrollHeight,
+		    d.body.offsetHeight, d.documentElement.offsetHeight,
+		    d.body.clientHeight, d.documentElement.clientHeight
+		),
+		width: Math.max(
+		    d.body.scrollWidth, d.documentElement.scrollWidth,
+		    d.body.offsetWidth, d.documentElement.offsetWidth,
+		    d.body.clientWidth, d.documentElement.clientWidth
+		)
+	    };
+	},
+	getViewport: function() {
+
+	    var viewPortWidth;
+	    var viewPortHeight;
+	    
+	    // the more standards compliant browsers (mozilla/netscape/opera/IE7)
+	    // use window.innerWidth and window.innerHeight
+	    if (typeof window.innerWidth != 'undefined') {
+		viewPortWidth = window.innerWidth,
+		viewPortHeight = window.innerHeight
+	    }
+	    
+	    // IE6 in standards compliant mode (i.e. with a valid doctype as the
+	    // first line in the document)
+	    else if (typeof document.documentElement != 'undefined'
+		     && typeof document.documentElement.clientWidth !=
+		     'undefined' && document.documentElement.clientWidth != 0) {
+		viewPortWidth = document.documentElement.clientWidth,
+		viewPortHeight = document.documentElement.clientHeight
+	    }
+	    
+	    // older versions of IE
+	    else {
+		viewPortWidth =
+		    document.getElementsByTagName('body')[0].clientWidth,
+		viewPortHeight =
+		    document.getElementsByTagName('body')[0].clientHeight
+	    }
+	    return {width: viewPortWidth, height: viewPortHeight};
+	}
+    };
+    
+    BOOMR.plugins.clicks = {
+	init: function(config) {
+	    var i, properties = ["click_url",      // URL to beacon
+				 "onbeforeunload"]; // Send the beacon when page is closed? 
+	    
+	    // This block is only needed if you actually have user configurable properties
+	    BOOMR.utils.pluginConfig(impl, config,"clicks", properties);
+	    
+	    // Other initialisation code here
+	    w.addEventListener("click",impl.handleEvent,true);
+	    w.addEventListener("beforeunload",impl.unload,true);
+	    return this;
+	},
+	
+	// Any other public methods would be defined here
+	
+	is_complete: function() {
+	    // This method should determine if the plugin has completed doing what it
+	    /// needs to do and return true if so or false otherwise
+	    impl.start_time = Date.now();
+	    return true;
+	}
+    };
+    
+}(window));
+
+
+
+
+


### PR DESCRIPTION
 Using this plugin you can track every click a user makes on a page.
 Configuring it is works as follows:

``` javascript
    BOOMR.init({
        beacon_url: "<beacon-url>",
        clicks: {
          click_url : "http://<seperate-clicktracking-beacon-url>",
          onbeforeunload : false
        }});
```

 Using a seperate url allows to have a seperate server responsible for
 handling a bigger load than your beacon server given that a typical
 user will be clicking more than once on an average page.

 You can use this plugin in one of two ways:
- `onbeforeunload : false` => Sends click-tracking beacons immediately
  upon click_events happening
- `onbeforeunload : true` => All Clicks that have been tracked are
  sent at once upon closing the page
  
  Data sent to the beacon-server will contain the following:
  - `element`: the name of the element that has been clicked
    (li,a,button,span etc)
  - `id`: possibly set ids on the element
  - `class`: a list of all classes assigned to the element
  - `document height/width`: the size of the document
  - `viewport height/width`: the size of the browser window
  
  Information like this allows you (for example) to drill deeper into
  what impact a change in the UI had(AB-Testing) or see which size most
  users view your page which can allow for better optimized media-queries
  for the formats used by the user base and heatmaps for the page as it
  exists.
